### PR TITLE
Service classloaders

### DIFF
--- a/tc-config-parser/src/main/java/org/terracotta/config/TCConfigurationParser.java
+++ b/tc-config-parser/src/main/java/org/terracotta/config/TCConfigurationParser.java
@@ -67,10 +67,10 @@ public class TCConfigurationParser {
   private static final Map<URI, ServiceConfigParser> serviceParsers = new HashMap<>();
 
   @SuppressWarnings("unchecked")
-  private static TcConfiguration parseStream(InputStream in, ErrorHandler eh, String source) throws IOException, SAXException {
+  private static TcConfiguration parseStream(InputStream in, ErrorHandler eh, String source, ClassLoader loader) throws IOException, SAXException {
     Collection<Source> schemaSources = new ArrayList<>();
 
-    for (ServiceConfigParser parser : loadConfigurationParserClasses()) {
+    for (ServiceConfigParser parser : loadConfigurationParserClasses(loader)) {
       schemaSources.add(parser.getXmlSchema());
       serviceParsers.put(parser.getNamespace(), parser);
     }
@@ -247,41 +247,41 @@ public class TCConfigurationParser {
     s.setBind(ParameterSubstitutor.substitute(s.getBind()));
   }
 
-  private static TcConfiguration convert(InputStream in, String path) throws IOException, SAXException {
+  private static TcConfiguration convert(InputStream in, String path, ClassLoader loader) throws IOException, SAXException {
     byte[] data = new byte[in.available()];
     in.read(data);
     in.close();
     ByteArrayInputStream bais = new ByteArrayInputStream(data);
 
-    return parseStream(bais, RethrowErrorHandler.INSTANCE, path);
+    return parseStream(bais, RethrowErrorHandler.INSTANCE, path, loader);
   }
 
-  public static TcConfiguration parse(File file) throws IOException, SAXException {
+  public static TcConfiguration parse(File file, ClassLoader loader) throws IOException, SAXException {
     FileInputStream in = null;
 
     try {
       in = new FileInputStream(file);
-      return convert(in, file.getParent());
+      return convert(in, file.getParent(), loader);
     } finally {
 
       IOUtils.closeQuietly(in);
     }
   }
 
-  public static TcConfiguration parse(String xmlText) throws IOException, SAXException {
-    return convert(new ByteArrayInputStream(xmlText.getBytes()), null);
+  public static TcConfiguration parse(String xmlText, ClassLoader loader) throws IOException, SAXException {
+    return convert(new ByteArrayInputStream(xmlText.getBytes()), null, loader);
   }
 
-  public static TcConfiguration parse(InputStream stream) throws IOException, SAXException {
-    return convert(stream, null);
+  public static TcConfiguration parse(InputStream stream, ClassLoader loader) throws IOException, SAXException {
+    return convert(stream, null, loader);
   }
 
-  public static TcConfiguration parse(URL url) throws IOException, SAXException {
-    return convert(url.openStream(), url.getPath());
+  public static TcConfiguration parse(URL url, ClassLoader loader) throws IOException, SAXException {
+    return convert(url.openStream(), url.getPath(), loader);
   }
 
-  public static TcConfiguration parse(InputStream in, Collection<SAXParseException> errors, String source) throws IOException, SAXException {
-    return parseStream(in, new CollectingErrorHandler(errors), source);
+  public static TcConfiguration parse(InputStream in, Collection<SAXParseException> errors, String source, ClassLoader loader) throws IOException, SAXException {
+    return parseStream(in, new CollectingErrorHandler(errors), source, loader);
   }
 
   private static class CollectingErrorHandler implements ErrorHandler {
@@ -329,9 +329,9 @@ public class TCConfigurationParser {
     }
   }
 
-  private static ServiceLoader<ServiceConfigParser> loadConfigurationParserClasses() {
-    return ServiceLoader.load(ServiceConfigParser.class,
-        TCConfigurationParser.class.getClassLoader());
+  private static ServiceLoader<ServiceConfigParser> loadConfigurationParserClasses(ClassLoader loader) {
+    return ServiceLoader.load(ServiceConfigParser.class,loader);
   }
-
+  
+  
 }

--- a/tc-config-parser/src/main/java/org/terracotta/config/TCConfigurationParser.java
+++ b/tc-config-parser/src/main/java/org/terracotta/config/TCConfigurationParser.java
@@ -255,6 +255,10 @@ public class TCConfigurationParser {
 
     return parseStream(bais, RethrowErrorHandler.INSTANCE, path, loader);
   }
+  
+  public static TcConfiguration parse(File f)  throws IOException, SAXException {
+    return parse(f, Thread.currentThread().getContextClassLoader());
+  }
 
   public static TcConfiguration parse(File file, ClassLoader loader) throws IOException, SAXException {
     FileInputStream in = null;
@@ -267,19 +271,35 @@ public class TCConfigurationParser {
       IOUtils.closeQuietly(in);
     }
   }
+  
+  public static TcConfiguration parse(String xmlText) throws IOException, SAXException {
+    return parse(xmlText, Thread.currentThread().getContextClassLoader());
+  }
 
   public static TcConfiguration parse(String xmlText, ClassLoader loader) throws IOException, SAXException {
     return convert(new ByteArrayInputStream(xmlText.getBytes()), null, loader);
   }
-
+  
+  public static TcConfiguration parse(InputStream stream) throws IOException, SAXException {
+    return parse(stream, Thread.currentThread().getContextClassLoader());
+  }
+  
   public static TcConfiguration parse(InputStream stream, ClassLoader loader) throws IOException, SAXException {
     return convert(stream, null, loader);
   }
-
+  
+  public static TcConfiguration parse(URL stream) throws IOException, SAXException {
+    return parse(stream, Thread.currentThread().getContextClassLoader());
+  }
+  
   public static TcConfiguration parse(URL url, ClassLoader loader) throws IOException, SAXException {
     return convert(url.openStream(), url.getPath(), loader);
   }
-
+  
+  public static TcConfiguration parse(InputStream in, Collection<SAXParseException> errors, String source) throws IOException, SAXException {
+    return parse(in, errors, source, Thread.currentThread().getContextClassLoader());
+  }
+  
   public static TcConfiguration parse(InputStream in, Collection<SAXParseException> errors, String source, ClassLoader loader) throws IOException, SAXException {
     return parseStream(in, new CollectingErrorHandler(errors), source, loader);
   }

--- a/tc-config-parser/src/test/java/org/terracotta/config/TCConfigurationParserTest.java
+++ b/tc-config-parser/src/test/java/org/terracotta/config/TCConfigurationParserTest.java
@@ -41,7 +41,7 @@ public class TCConfigurationParserTest {
   public void testSimpleTCParser() throws Exception {
 
     URL resource = Thread.currentThread().getContextClassLoader().getResource("tc-configuration-1.xml");
-    TcConfiguration conf = TCConfigurationParser.parse(resource, getClass().getClassLoader());
+    TcConfiguration conf = TCConfigurationParser.parse(resource);
     TcConfig tcConfig = conf.getPlatformConfiguration();
 
     assertThat("servers should not be secured", tcConfig.getServers().isSecure(), is(false));
@@ -79,7 +79,7 @@ public class TCConfigurationParserTest {
   @Test
   public void testServiceParser() throws Exception {
     URL resource = Thread.currentThread().getContextClassLoader().getResource("tc-configuration-service.xml");
-    TcConfiguration conf = TCConfigurationParser.parse(resource, getClass().getClassLoader());
+    TcConfiguration conf = TCConfigurationParser.parse(resource);
 
     Map<String, List<ServiceProviderConfiguration>> serviceConfigurations = conf.getServiceConfigurations();
 
@@ -92,7 +92,7 @@ public class TCConfigurationParserTest {
   @Test
   public void testServiceOverrides() throws Exception {
     URL resource = Thread.currentThread().getContextClassLoader().getResource("tc-configuration-service-override.xml");
-    TcConfiguration conf = TCConfigurationParser.parse(resource, getClass().getClassLoader());
+    TcConfiguration conf = TCConfigurationParser.parse(resource);
 
     Map<String, List<ServiceProviderConfiguration>> serviceConfigurations = conf.getServiceConfigurations();
 
@@ -106,7 +106,7 @@ public class TCConfigurationParserTest {
   public void testEmptyService() throws Exception {
 
     URL resource = Thread.currentThread().getContextClassLoader().getResource("tc-configuration-empty-service.xml");
-    TcConfiguration conf = TCConfigurationParser.parse(resource, getClass().getClassLoader());
+    TcConfiguration conf = TCConfigurationParser.parse(resource);
 
     assertThat("there should be no services", conf.getServiceConfigurations().size(), is(0));
 

--- a/tc-config-parser/src/test/java/org/terracotta/config/TCConfigurationParserTest.java
+++ b/tc-config-parser/src/test/java/org/terracotta/config/TCConfigurationParserTest.java
@@ -41,7 +41,7 @@ public class TCConfigurationParserTest {
   public void testSimpleTCParser() throws Exception {
 
     URL resource = Thread.currentThread().getContextClassLoader().getResource("tc-configuration-1.xml");
-    TcConfiguration conf = TCConfigurationParser.parse(resource);
+    TcConfiguration conf = TCConfigurationParser.parse(resource, getClass().getClassLoader());
     TcConfig tcConfig = conf.getPlatformConfiguration();
 
     assertThat("servers should not be secured", tcConfig.getServers().isSecure(), is(false));
@@ -79,7 +79,7 @@ public class TCConfigurationParserTest {
   @Test
   public void testServiceParser() throws Exception {
     URL resource = Thread.currentThread().getContextClassLoader().getResource("tc-configuration-service.xml");
-    TcConfiguration conf = TCConfigurationParser.parse(resource);
+    TcConfiguration conf = TCConfigurationParser.parse(resource, getClass().getClassLoader());
 
     Map<String, List<ServiceProviderConfiguration>> serviceConfigurations = conf.getServiceConfigurations();
 
@@ -92,7 +92,7 @@ public class TCConfigurationParserTest {
   @Test
   public void testServiceOverrides() throws Exception {
     URL resource = Thread.currentThread().getContextClassLoader().getResource("tc-configuration-service-override.xml");
-    TcConfiguration conf = TCConfigurationParser.parse(resource);
+    TcConfiguration conf = TCConfigurationParser.parse(resource, getClass().getClassLoader());
 
     Map<String, List<ServiceProviderConfiguration>> serviceConfigurations = conf.getServiceConfigurations();
 
@@ -106,7 +106,7 @@ public class TCConfigurationParserTest {
   public void testEmptyService() throws Exception {
 
     URL resource = Thread.currentThread().getContextClassLoader().getResource("tc-configuration-empty-service.xml");
-    TcConfiguration conf = TCConfigurationParser.parse(resource);
+    TcConfiguration conf = TCConfigurationParser.parse(resource, getClass().getClassLoader());
 
     assertThat("there should be no services", conf.getServiceConfigurations().size(), is(0));
 


### PR DESCRIPTION
Service configurations should have the option of using a special passed in class loader.  Anything without a passed in class loader should use the thread context loader.