### PR TITLE
Fix #6 - Add the ability to add and configure entities

### DIFF
--- a/tcconfig-schema/src/main/resources/terracotta.xsd
+++ b/tcconfig-schema/src/main/resources/terracotta.xsd
@@ -32,11 +32,20 @@
           <xs:annotation>
             <xs:documentation xml:lang="en">
               This section defines the list of services which are provided to the server by the platform.
-              Each service provider defines their own schema and parsing responsiblity is left upto the service provider.
+              Each service provider defines their own schema and parsing responsiblity is left up to the service provider.
             </xs:documentation>
           </xs:annotation>
         </xs:element>
-
+        
+        <xs:element name="entities" type="tc:entities" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              This section defines the list of entities that have the lifecycle of the server.  Unlike entities created by 
+              a client, these entities cannot be deleted.  
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        
         <xs:element name="tc-properties" type="tc:tc-properties" minOccurs="0">
           <xs:annotation>
             <xs:documentation>
@@ -99,6 +108,12 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="entities">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="entity" type="tc:entity"/>
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:complexType name="service-overrides">
     <xs:sequence minOccurs="0" maxOccurs="unbounded">
       <xs:element name="service-override" type="tc:service-override"/>
@@ -111,7 +126,29 @@
     </xs:choice>
     <xs:attribute name="id" type="xs:ID" use="required"/>
   </xs:complexType>
-
+  
+  <xs:complexType name="entity">
+    <xs:sequence>
+      <xs:element name="type" type="tc:qualified-class-name" minOccurs="1" maxOccurs="1" />
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="version" type="tc:non-negative-int" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="configuration" minOccurs="0" maxOccurs="1"> 
+        <xs:complexType>
+            <xs:choice>
+              <xs:any namespace="##other" minOccurs="0" maxOccurs="1" processContents="skip"/>
+              <xs:element name="properties">
+                  <xs:complexType>
+                      <xs:sequence>
+                          <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                      </xs:sequence>
+                  </xs:complexType>
+              </xs:element>
+            </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
   <xs:complexType name="service-override">
     <xs:choice>
       <xs:any namespace="##other" minOccurs="0" maxOccurs="1" processContents="skip"/>


### PR DESCRIPTION
Proposed configuration to add entities via the server.  With this proposal there will be two ways to configure an entity via xml.  Either a properties map express in xml elements or the text of an xml fragment.