### PR TITLE
Fix #44 : Remove Apache Commons IO Dependency

### DIFF
--- a/tc-config-parser/pom.xml
+++ b/tc-config-parser/pom.xml
@@ -44,10 +44,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/tc-config-parser/src/main/java/org/terracotta/config/TCConfigurationParser.java
+++ b/tc-config-parser/src/main/java/org/terracotta/config/TCConfigurationParser.java
@@ -20,7 +20,6 @@ package org.terracotta.config;
 
 
 import org.terracotta.config.util.DefaultSubstitutor;
-import org.apache.commons.io.IOUtils;
 import org.terracotta.config.util.ParameterSubstitutor;
 import org.terracotta.entity.ServiceProviderConfiguration;
 import org.w3c.dom.Element;
@@ -266,14 +265,8 @@ public class TCConfigurationParser {
   }
 
   public static TcConfiguration parse(File file, ClassLoader loader) throws IOException, SAXException {
-    FileInputStream in = null;
-
-    try {
-      in = new FileInputStream(file);
+    try (FileInputStream in = new FileInputStream(file)) {
       return convert(in, file.getParent(), loader);
-    } finally {
-
-      IOUtils.closeQuietly(in);
     }
   }
   


### PR DESCRIPTION
This PR removes "Apache Commons IO" dependency from tc-config-parser module, new dependency tree below:

````
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ tc-config-parser ---
[INFO] org.terracotta.internal:tc-config-parser:jar:10.3-SNAPSHOT
[INFO] +- org.terracotta:entity-server-api:jar:1.3.0-pre1:compile
[INFO] |  \- org.terracotta:entity-common-api:jar:1.3.0-pre1:compile
[INFO] +- org.terracotta:tcconfig-schema:jar:10.3-SNAPSHOT:compile
[INFO] +- junit:junit:jar:4.11:test
[INFO] +- org.mockito:mockito-core:jar:1.9.5:test
[INFO] |  \- org.objenesis:objenesis:jar:1.0:test
[INFO] \- org.hamcrest:hamcrest-core:jar:1.3:test
```