### PR TITLE
Fix #48: Improve terracotta config XSD to differentiate types accepted in plugins

### DIFF
--- a/tc-config-parser/pom.xml
+++ b/tc-config-parser/pom.xml
@@ -70,16 +70,33 @@
     </testResources>
     <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>jaxb2-maven-plugin</artifactId>
+            <groupId>org.jvnet.jaxb2.maven2</groupId>
+            <artifactId>maven-jaxb2-plugin</artifactId>
+            <version>0.12.3</version>
             <executions>
                 <execution>
                     <id>test</id>
                     <goals>
-                        <goal>testXjc</goal>
+                        <goal>generate</goal>
                     </goals>
                 </execution>
             </executions>
+            <configuration>
+              <strict>false</strict>
+              <schemaDirectory>src/test/xsd</schemaDirectory>
+              <schemaIncludes>
+                <include>*.xsd</include>
+              </schemaIncludes>
+              <catalogs>
+                <catalog>
+                  <dependencyResource>
+                    <groupId>org.terracotta</groupId>
+                    <artifactId>tcconfig-schema</artifactId>
+                    <resource>catalog.cat</resource>
+                  </dependencyResource>
+                </catalog>
+              </catalogs>
+            </configuration>
         </plugin>
     </plugins>
   </build>

--- a/tc-config-parser/src/test/java/org/terracotta/config/BarConfigurationParser.java
+++ b/tc-config-parser/src/test/java/org/terracotta/config/BarConfigurationParser.java
@@ -50,7 +50,7 @@ public class BarConfigurationParser implements ExtendedConfigParser {
   public Object parse(Element fragment, String source) {
     Bar foo = null;
     try {
-      JAXBContext jc = JAXBContext.newInstance("com.example.bar");
+      JAXBContext jc = JAXBContext.newInstance("com.example.bar:org.terracotta.config");
       Unmarshaller u = jc.createUnmarshaller();
       foo = u.unmarshal(fragment, Bar.class).getValue();
       DefaultSubstitutor.applyDefaults(foo);

--- a/tc-config-parser/src/test/java/org/terracotta/config/FooServiceConfigurationParser.java
+++ b/tc-config-parser/src/test/java/org/terracotta/config/FooServiceConfigurationParser.java
@@ -69,7 +69,7 @@ public class FooServiceConfigurationParser implements ServiceConfigParser {
   public ServiceProviderConfiguration parse(Element fragment, String source) {
     Foo foo = null;
     try {
-      JAXBContext jc = JAXBContext.newInstance("com.example.foo");
+      JAXBContext jc = JAXBContext.newInstance("com.example.foo:org.terracotta.config");
       Unmarshaller u = jc.createUnmarshaller();
       foo = u.unmarshal(fragment, Foo.class).getValue();
       DefaultSubstitutor.applyDefaults(foo);

--- a/tc-config-parser/src/test/resources/tc-configuration-empty-service.xml
+++ b/tc-config-parser/src/test/resources/tc-configuration-empty-service.xml
@@ -22,7 +22,5 @@
                  xmlns:tccon="http://www.terracotta.org/config">
 
   <tccon:plugins>
-    <tccon:service>
-    </tccon:service>
   </tccon:plugins>
 </tccon:tc-config>

--- a/tc-config-parser/src/test/xsd/bar.xsd
+++ b/tc-config-parser/src/test/xsd/bar.xsd
@@ -36,9 +36,11 @@
 
 <xs:schema version="1.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tc="http://www.terracotta.org/config"
            elementFormDefault="qualified"
            targetNamespace="http://www.example.com/bar">
-  <xs:element name="bar">
+  <xs:import namespace="http://www.terracotta.org/config"/>
+  <xs:element name="bar" substitutionGroup="tc:config-content">
     <xs:complexType>
       <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>

--- a/tc-config-parser/src/test/xsd/foo.xsd
+++ b/tc-config-parser/src/test/xsd/foo.xsd
@@ -36,9 +36,11 @@
 
 <xs:schema version="1.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tc="http://www.terracotta.org/config"
            elementFormDefault="qualified"
            targetNamespace="http://www.example.com/foo">
-  <xs:element name="foo">
+  <xs:import namespace="http://www.terracotta.org/config"/>
+  <xs:element name="foo" substitutionGroup="tc:service-content">
     <xs:complexType>
       <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>

--- a/tcconfig-schema/pom.xml
+++ b/tcconfig-schema/pom.xml
@@ -44,6 +44,9 @@
         <directory>src/main/xsd/</directory>
         <filtering>true</filtering>
       </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
     </resources>
 
     <plugins>

--- a/tcconfig-schema/src/main/resources/catalog.cat
+++ b/tcconfig-schema/src/main/resources/catalog.cat
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Configuration.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+#
+PUBLIC "http://www.terracotta.org/config" terracotta.xsd

--- a/tcconfig-schema/src/main/xsd/terracotta.xsd
+++ b/tcconfig-schema/src/main/xsd/terracotta.xsd
@@ -21,6 +21,7 @@
 <xs:schema
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:tc="http://www.terracotta.org/config"
+    xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.0"
     targetNamespace="http://www.terracotta.org/config"
     elementFormDefault="qualified"
     version="${project.version}">
@@ -104,7 +105,7 @@
   <xs:complexType name="services">
     <xs:sequence minOccurs="0" maxOccurs="unbounded">
       <xs:choice>
-        <xs:element name="config" type="tc:service"/>
+        <xs:element name="config" type="tc:config"/>
         <xs:element name="service" type="tc:service"/>
       </xs:choice>
     </xs:sequence>
@@ -116,11 +117,33 @@
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="service">
-    <xs:choice>
-      <xs:any namespace="##other" minOccurs="0" maxOccurs="1" processContents="skip"/>
-    </xs:choice>
+  <xs:complexType name="config">
+    <xs:sequence>
+      <xs:element ref="tc:config-content" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
   </xs:complexType>
+
+  <xs:element name="config-content" abstract="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:dom/>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:complexType name="service">
+    <xs:sequence>
+      <xs:element ref="tc:service-content" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:element name="service-content" abstract="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:dom/>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
   
   <xs:complexType name="entity">
     <xs:sequence>


### PR DESCRIPTION
This PR adds better tool support as mentioned in #48, going forward `Extended configurations`  have to specify `config-content` and `Service Provider configurations` `service-content` in `substitutionGroup` attribute of root element. 

e.g.

````
<xs:schema version="1.0"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:tc="http://www.terracotta.org/config"
           elementFormDefault="qualified"
           targetNamespace="http://www.example.com/foo">
  <xs:import namespace="http://www.terracotta.org/config"/>
  <xs:element name="foo" substitutionGroup="tc:service-content">
    <xs:complexType>
      <xs:attribute name="name" type="xs:string" use="required"/>
    </xs:complexType>
  </xs:element>
</xs:schema>
````
 
The `config-content` and `service-content` tags present in `terracotta.xsd` so this xsd needs to imported. I have exported this terracotta.xsd location using `catalog.cat` file, which is present in `tcconfig-schema` jar. 

An example configuration to use catalogs with maven-jaxb2-plugin

````
<catalogs>
  <catalog>
     <dependencyResource>
        <groupId>org.terracotta</groupId>
        <artifactId>tcconfig-schema</artifactId>
        <resource>catalog.cat</resource>
     </dependencyResource>
  </catalog>
</catalogs>
````

@ljacomet Let me know if there is a better way to do this change. 



