### PR TITLE
Issue #81 : Use default maven source plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,13 +78,6 @@
             </execution>
           </executions>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <configuration>
-            <attach>false</attach>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
* to allow the install and deploy mojos to attach sources jars