### PR TITLE
 Host Name is substituted with wrong value when server is configured only with bind attribute.

### DIFF
--- a/tc-config-parser/src/main/java/org/terracotta/config/TCConfigurationParser.java
+++ b/tc-config-parser/src/main/java/org/terracotta/config/TCConfigurationParser.java
@@ -212,10 +212,12 @@ public class TCConfigurationParser {
 
   private static void initializeNameAndHost(Server server) {
     if (server.getHost() == null || server.getHost().trim().length() == 0) {
-      if (server.getName() == null) {
-        server.setHost("%i");
-      } else {
+      if (server.getName() != null) {
         server.setHost(server.getName());
+      } else if (!WILDCARD_IP.equals(server.getBind())) {
+        server.setHost(server.getBind());
+      } else {
+        server.setHost("%i");
       }
     }
 

--- a/tc-config-parser/src/test/java/org/terracotta/config/TCConfigurationParserTest.java
+++ b/tc-config-parser/src/test/java/org/terracotta/config/TCConfigurationParserTest.java
@@ -165,4 +165,23 @@ public class TCConfigurationParserTest {
     assertThat(voter, notNullValue());
     assertThat(voter.getCount(), is(2));
   }
+
+  @Test
+  public void testTCParserWithServerHavingOnlyBindAttribute() throws Exception {
+    URL resource = Thread.currentThread()
+                         .getContextClassLoader()
+                         .getResource("tc-configuration-server-with-only-bind-attribute.xml");
+    TcConfiguration conf = TCConfigurationParser.parse(resource);
+    TcConfig tcConfig = conf.getPlatformConfiguration();
+
+    List<Server> servers = tcConfig.getServers().getServer();
+    assertThat("Server configuration should not be null", servers, notNullValue());
+    assertThat("Number of servers should be 1", servers.size(), is(1));
+
+    Server s = servers.get(0);
+
+    assertThat("Server hostname should be 127.0.0.1", s.getHost(), is("127.0.0.1"));
+    assertThat("Server bind port should be 127.0.0.1", s.getBind(), is("127.0.0.1"));
+    assertThat("Server name should be 127.0.0.1:9410", s.getName(), is("127.0.0.1:9410"));
+  }
 }

--- a/tc-config-parser/src/test/resources/tc-configuration-server-with-only-bind-attribute.xml
+++ b/tc-config-parser/src/test/resources/tc-configuration-server-with-only-bind-attribute.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ The contents of this file are subject to the Terracotta Public License Version
+  ~ 2.0 (the "License"); You may not use this file except in compliance with the
+  ~ License. You may obtain a copy of the License at
+  ~
+  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~
+  ~ Software distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+  ~ the specific language governing rights and limitations under the License.
+  ~
+  ~ The Covered Software is Terracotta Configuration.
+  ~
+  ~ The Initial Developer of the Covered Software is
+  ~ Terracotta, Inc., a Software AG company
+  ~
+  -->
+
+<tccon:tc-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:tccon="http://www.terracotta.org/config">
+
+  <tccon:servers>
+    <tccon:server bind="127.0.0.1">
+    </tccon:server>
+  </tccon:servers>
+
+</tccon:tc-config>


### PR DESCRIPTION
For reference - 
https://github.com/Terracotta-OSS/terracotta-configuration/issues/96.