### PR TITLE
add default configuration provider for the terracotta server.  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
+        <artifactId>hamcrest-all</artifactId>
         <version>1.3</version>
         <scope>test</scope>
       </dependency>
@@ -81,6 +81,11 @@
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
         <version>2.3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <version>1.3.1</version>
       </dependency>
     </dependencies>
 
@@ -98,26 +103,6 @@
           <groupId>org.jvnet.jaxb2.maven2</groupId>
           <artifactId>maven-jaxb2-plugin</artifactId>
           <version>0.13.3</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.2.1</version>
-          <executions>
-            <execution>
-              <id>assemble-sources</id>
-              <phase>package</phase>
-              <goals>
-                <goal>single</goal>
-              </goals>
-              <configuration>
-                <descriptors>
-                  <descriptor>${basedir}/../src/assemble/sources.xml</descriptor>
-                </descriptors>
-                <appendAssemblyId>true</appendAssemblyId>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/tc-config-parser/pom.xml
+++ b/tc-config-parser/pom.xml
@@ -37,6 +37,7 @@
       <groupId>org.terracotta</groupId>
       <artifactId>entity-server-api</artifactId>
       <version>${terracotta-apis.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>
@@ -46,6 +47,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -55,16 +57,28 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.18.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
       <scope>runtime</scope>
     </dependency>
+  <dependency>
+    <groupId>commons-cli</groupId>
+    <artifactId>commons-cli</artifactId>
+  </dependency>  
   </dependencies>
   <build>
     <testResources>

--- a/tc-config-parser/src/assemble/distribution.xml
+++ b/tc-config-parser/src/assemble/distribution.xml
@@ -17,17 +17,21 @@
   -->
 
 <assembly>
-  <id>sources</id>
+  <id>distribution</id>
   <formats>
-    <format>jar</format>
+    <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <outputDirectory>/</outputDirectory>
-      <directory>${project.build.directory}/generated-sources/xjc</directory>
+      <directory>${project.build.directory}</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+        <include>${project.build.finalName}/*</include>
+      </includes>
       <excludes>
-        <exclude>.staleFlag</exclude>
+        <exclude>*sources.jar</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/tc-config-parser/src/main/resources/META-INF/services/org.terracotta.config.ConfigurationProvider
+++ b/tc-config-parser/src/main/resources/META-INF/services/org.terracotta.config.ConfigurationProvider
@@ -1,0 +1,1 @@
+org.terracotta.config.provider.DefaultConfigurationProvider

--- a/tc-config-parser/src/test/resources/logback-test.xml
+++ b/tc-config-parser/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration debug="true">
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d %p - %m%n</pattern>
+      <charset>utf8</charset>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+</configuration>

--- a/tc-config-parser/src/test/resources/simple-tc-config.xml
+++ b/tc-config-parser/src/test/resources/simple-tc-config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~
+  ~  The contents of this file are subject to the Terracotta Public License Version
+  ~  2.0 (the "License"); You may not use this file except in compliance with the
+  ~  License. You may obtain a copy of the License at
+  ~
+  ~  http://terracotta.org/legal/terracotta-public-license.
+  ~
+  ~  Software distributed under the License is distributed on an "AS IS" basis,
+  ~  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+  ~  the specific language governing rights and limitations under the License.
+  ~
+  ~  The Covered Software is Terracotta Core.
+  ~
+  ~  The Initial Developer of the Covered Software is
+  ~  Terracotta, Inc., a Software AG company
+  ~
+  -->
+
+<!-- This config file is used by the server and bootjar tool when none is specified. -->
+
+<tc-config xmlns="http://www.terracotta.org/config">
+    <servers>
+        <server>
+            <logs>%(user.home)/terracotta/server-logs</logs>
+        </server>
+    </servers>
+</tc-config>


### PR DESCRIPTION
Moving the default xml configuration provider to this repository from tc-core.  This adjusts the dependency graph from tc-api->tc-configuration->tc-core to tc-api->tc-core->tc-configuration.  