### PR TITLE
Remove POM repositories elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <properties>
     <skip.testjar>true</skip.testjar>
     <java.build.version>1.8</java.build.version>
-    <terracotta-apis.version>1.7.0</terracotta-apis.version>
+    <terracotta-apis.version>1.8.2</terracotta-apis.version>
   </properties>
 
   <dependencyManagement>
@@ -139,12 +139,9 @@
 
   <repositories>
     <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
       <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
+      <url>https://repo.terracotta.org/maven2</url>
+      <snapshots><enabled>false</enabled></snapshots>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This commit reduces the repositories and pluginRepositories elements
to those required to locate the direct dependencies of this project.
More specifically, the SNAPSHOT repositories are removed -- inclusion
of SNAPSHOT repositories interferes with the use of range-based version
specifications.  Should a developer want to include a SNAPSHOT release
in a build, local addition of the SNAPSHOT repositories can be employed.